### PR TITLE
Use correct option when checking dupe instances

### DIFF
--- a/lib/spooky.js
+++ b/lib/spooky.js
@@ -102,7 +102,8 @@ function Spooky(options, callback) {
     serializeMethods(options.casper);
 
     if (options.child.transport === 'http') {
-        this._child = Spooky._instances[options.port] = this._spawnChild();
+        this._child =
+          Spooky._instances[options.child.port] = this._spawnChild();
 
         this._rpcClient = new tinyjsonrpc.StreamClient({
             server: new RequestStream({


### PR DESCRIPTION
Previously, the code looked at `options.port`, which isn't a thing. So, the port
was always the string `'undefined'`. Instead, look at `options.child.port`.

[fix #124]